### PR TITLE
Fixing the stack trace printing issue

### DIFF
--- a/src/main/java/com/ksm/domino/cli/Domino.java
+++ b/src/main/java/com/ksm/domino/cli/Domino.java
@@ -28,38 +28,38 @@ import picocli.CommandLine;
 
 @TopCommand
 @Command(name = "domino",
-            header = "%n@|green Domino CLI|@",
-            description = "%n@|blue Domino Data Lab Command Line Interface is a client to used provision and control Domino.|@%n",
-            mixinStandardHelpOptions = true,
-            versionProvider = VersionProvider.class,
-            defaultValueProvider = EnvironmentVariableDefaultProvider.class,
-            subcommands = {
-                        Collaborator.class,
-                        Dataset.class,
-                        DataSource.class,
-                        Goal.class,
-                        Job.class,
-                        User.class,
-                        Project.class,
-                        Run.class,
-                        Server.class
-            })
+        header = "%n@|green Domino CLI|@",
+        description = "%n@|blue Domino Data Lab Command Line Interface is a client to used provision and control Domino.|@%n",
+        mixinStandardHelpOptions = true,
+        versionProvider = VersionProvider.class,
+        defaultValueProvider = EnvironmentVariableDefaultProvider.class,
+        subcommands = {
+                Collaborator.class,
+                Dataset.class,
+                DataSource.class,
+                Goal.class,
+                Job.class,
+                User.class,
+                Project.class,
+                Run.class,
+                Server.class
+        })
 public class Domino implements Runnable {
 
     @Option(names = {"-k",
-                "--key"}, description = "Domino API Key.", defaultValue = "DOMINO_API_KEY", scope = ScopeType.INHERIT)
+            "--key"}, description = "Domino API Key.", defaultValue = "DOMINO_API_KEY", scope = ScopeType.INHERIT)
     public String apiKey;
 
     @Option(names = {"-u",
-                "--url"}, description = "Domino API URL.", defaultValue = "DOMINO_API_URL", scope = ScopeType.INHERIT)
+            "--url"}, description = "Domino API URL.", defaultValue = "DOMINO_API_URL", scope = ScopeType.INHERIT)
     public String apiUrl;
 
     @Option(names = {"-t",
-                "--timeout"}, description = "Timeout in seconds waiting for Domino responses.", defaultValue = "60", scope = ScopeType.INHERIT)
+            "--timeout"}, description = "Timeout in seconds waiting for Domino responses.", defaultValue = "60", scope = ScopeType.INHERIT)
     public long timeoutSeconds;
 
     @Option(names = {"-o",
-                "--output"}, description = "Output format TEXT, JSON, XML", defaultValue = "JSON", scope = ScopeType.INHERIT)
+            "--output"}, description = "Output format TEXT, JSON, XML", defaultValue = "JSON", scope = ScopeType.INHERIT)
     public OutputFormat outputFormat;
 
     @Spec

--- a/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
+++ b/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
@@ -122,8 +122,6 @@ public abstract class AbstractDominoCommand implements Runnable {
             Validate.notBlank(param,
                     String.format("Missing the required parameter '%s' when calling '%s'.", parameterName, command));
         } catch (Exception e) {
-            // this will catch either NullPointerException or IllegalArgumentException from above
-            // throwing an Illegal argument exception shows the help menu automatically
             throw new IllegalArgumentException(e.getMessage());
         }
         return param;

--- a/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
+++ b/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
@@ -1,13 +1,5 @@
 package com.ksm.domino.cli.command;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.time.Duration;
-import java.util.Map;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
-
 import com.dominodatalab.api.invoker.ApiClient;
 import com.dominodatalab.api.invoker.ApiException;
 import com.dominodatalab.client.TrustAllManager;
@@ -20,9 +12,15 @@ import com.fasterxml.jackson.dataformat.toml.TomlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.ksm.domino.cli.Domino;
-
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.Map;
 
 /**
  * Abstract base class that any command that needs to access Domino should extend.
@@ -53,11 +51,14 @@ public abstract class AbstractDominoCommand implements Runnable {
         } catch (ApiException ex) {
             throw new RuntimeException(ex.getMessage());
         } catch (IllegalArgumentException ex) {
-            System.out.println(ex.getMessage());
+            // color the message so it stands out
+            String BRIGHT_RED_TEXT = "\033[0;91m";
+            String RESET_TEXT_COLOR = "\033[0m";
+            System.err.println(BRIGHT_RED_TEXT + ex.getMessage() + RESET_TEXT_COLOR);
+
             // if the command was invoked without proper params, show the usage help
             spec.commandLine().usage(System.err);
         } catch (Exception ex) {
-            System.out.println("so this is the issue");
             throw new RuntimeException(ex);
         }
     }

--- a/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
+++ b/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.ksm.domino.cli.Domino;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
 import picocli.CommandLine.Option;
 
 import java.net.URI;
@@ -118,11 +117,9 @@ public abstract class AbstractDominoCommand implements Runnable {
 
     public String getRequiredParam(Map<String, String> parameters, String parameterName, String command) {
         String param = parameters.get(parameterName);
-        try {
-            Validate.notBlank(param,
+        if (StringUtils.isBlank(param)) {
+            throw new IllegalArgumentException(
                     String.format("Missing the required parameter '%s' when calling '%s'.", parameterName, command));
-        } catch (Exception e) {
-            throw new IllegalArgumentException(e.getMessage());
         }
         return param;
     }

--- a/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
+++ b/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.ksm.domino.cli.Domino;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
-import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
 import java.net.URI;
@@ -26,9 +25,6 @@ import java.util.Map;
  * Abstract base class that any command that needs to access Domino should extend.
  */
 public abstract class AbstractDominoCommand implements Runnable {
-    @CommandLine.Spec
-    CommandLine.Model.CommandSpec spec;
-
     /**
      * Default target path of the Domino API
      */
@@ -51,13 +47,6 @@ public abstract class AbstractDominoCommand implements Runnable {
         } catch (ApiException ex) {
             throw new RuntimeException(ex.getMessage());
         } catch (IllegalArgumentException ex) {
-//            // color the message so it stands out
-//            String BRIGHT_RED_TEXT = "\033[0;91m";
-//            String RESET_TEXT_COLOR = "\033[0m";
-//            System.err.println(BRIGHT_RED_TEXT + ex.getMessage() + RESET_TEXT_COLOR);
-//
-//            // if the command was invoked without proper params, show the usage help
-//            spec.commandLine().usage(System.err);
             throw ex;
         } catch (Exception ex) {
             throw new RuntimeException(ex);
@@ -82,7 +71,6 @@ public abstract class AbstractDominoCommand implements Runnable {
             client.setBasePath(DEFAULT_DOMINO_API_BASE_PATH);
         }
         return client;
-
     }
 
     /**
@@ -130,13 +118,14 @@ public abstract class AbstractDominoCommand implements Runnable {
 
     public String getRequiredParam(Map<String, String> parameters, String parameterName, String command) {
         String param = parameters.get(parameterName);
-//        try {
+        try {
             Validate.notBlank(param,
                     String.format("Missing the required parameter '%s' when calling '%s'.", parameterName, command));
-//        } catch (Exception e) {
-//            throw new IllegalArgumentException(
-//                    String.format("Missing the required parameter '%s' when calling '%s'.", parameterName, command), e);
-//        }
+        } catch (Exception e) {
+            // this will catch either NullPointerException or IllegalArgumentException from above
+            // throwing an Illegal argument exception shows the help menu automatically
+            throw new IllegalArgumentException(e.getMessage());
+        }
         return param;
     }
 }

--- a/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
+++ b/src/main/java/com/ksm/domino/cli/command/AbstractDominoCommand.java
@@ -51,13 +51,14 @@ public abstract class AbstractDominoCommand implements Runnable {
         } catch (ApiException ex) {
             throw new RuntimeException(ex.getMessage());
         } catch (IllegalArgumentException ex) {
-            // color the message so it stands out
-            String BRIGHT_RED_TEXT = "\033[0;91m";
-            String RESET_TEXT_COLOR = "\033[0m";
-            System.err.println(BRIGHT_RED_TEXT + ex.getMessage() + RESET_TEXT_COLOR);
-
-            // if the command was invoked without proper params, show the usage help
-            spec.commandLine().usage(System.err);
+//            // color the message so it stands out
+//            String BRIGHT_RED_TEXT = "\033[0;91m";
+//            String RESET_TEXT_COLOR = "\033[0m";
+//            System.err.println(BRIGHT_RED_TEXT + ex.getMessage() + RESET_TEXT_COLOR);
+//
+//            // if the command was invoked without proper params, show the usage help
+//            spec.commandLine().usage(System.err);
+            throw ex;
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -129,13 +130,13 @@ public abstract class AbstractDominoCommand implements Runnable {
 
     public String getRequiredParam(Map<String, String> parameters, String parameterName, String command) {
         String param = parameters.get(parameterName);
-        try {
+//        try {
             Validate.notBlank(param,
                     String.format("Missing the required parameter '%s' when calling '%s'.", parameterName, command));
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    String.format("Missing the required parameter '%s' when calling '%s'.", parameterName, command), e);
-        }
+//        } catch (Exception e) {
+//            throw new IllegalArgumentException(
+//                    String.format("Missing the required parameter '%s' when calling '%s'.", parameterName, command), e);
+//        }
         return param;
     }
 }

--- a/src/main/java/com/ksm/domino/cli/command/job/JobGet.java
+++ b/src/main/java/com/ksm/domino/cli/command/job/JobGet.java
@@ -18,10 +18,10 @@ public class JobGet extends AbstractDominoCommand {
 
     private static final String NAME = "job get";
 
-    @CommandLine.Parameters(description = "@|blue Required parameters:%n jobId=12345%n|@%n", mapFallbackValue = "")
-    private final Map<String, String> parameters = new LinkedHashMap<>(3);
+//    @CommandLine.Parameters(description = "@|blue Required parameters:%n jobId=12345%n|@%n", mapFallbackValue = "")
+//    private final Map<String, String> parameters = new LinkedHashMap<>(3);
 
-    @CommandLine.Parameters(description = "Job Id to get", paramLabel = "jobId", arity = "1")
+    @CommandLine.Parameters(description = "Job Id to get%n", paramLabel = "jobId")
     private String alternateJobId;
 
     @Override

--- a/src/main/java/com/ksm/domino/cli/command/job/JobGet.java
+++ b/src/main/java/com/ksm/domino/cli/command/job/JobGet.java
@@ -18,22 +18,14 @@ public class JobGet extends AbstractDominoCommand {
 
     private static final String NAME = "job get";
 
-//    @CommandLine.Parameters(description = "@|blue Required parameters:%n jobId=12345%n|@%n", mapFallbackValue = "")
-//    private final Map<String, String> parameters = new LinkedHashMap<>(3);
-
-    @CommandLine.Parameters(description = "Job Id to get%n", paramLabel = "jobId")
-    private String alternateJobId;
+    @CommandLine.Parameters(description = "@|blue Required parameters:%n jobId=12345%n|@%n", mapFallbackValue = "")
+    private final Map<String, String> parameters = new LinkedHashMap<>(3);
 
     @Override
     public void execute() throws Exception {
-//        System.out.printf("jobId a different way: %s\n", alternateJobId);
-//        if(extraParams != null){
-//            System.out.printf("the extra param is: %s\n", extraParams);
-//        }
-
-//        String jobId = getRequiredParam(parameters, "jobId", NAME);
+        String jobId = getRequiredParam(parameters, "jobId", NAME);
         JobsApi api = new JobsApi(getApiClient(parent.domino));
-        DominoJobsInterfaceJob job = api.getJob(alternateJobId);
+        DominoJobsInterfaceJob job = api.getJob(jobId);
         output(job, parent.domino);
     }
 }

--- a/src/main/java/com/ksm/domino/cli/command/job/JobGet.java
+++ b/src/main/java/com/ksm/domino/cli/command/job/JobGet.java
@@ -21,11 +21,19 @@ public class JobGet extends AbstractDominoCommand {
     @CommandLine.Parameters(description = "@|blue Required parameters:%n jobId=12345%n|@%n", mapFallbackValue = "")
     private final Map<String, String> parameters = new LinkedHashMap<>(3);
 
+    @CommandLine.Parameters(description = "Job Id to get", paramLabel = "jobId", arity = "1")
+    private String alternateJobId;
+
     @Override
     public void execute() throws Exception {
-        String jobId = getRequiredParam(parameters, "jobId", NAME);
+//        System.out.printf("jobId a different way: %s\n", alternateJobId);
+//        if(extraParams != null){
+//            System.out.printf("the extra param is: %s\n", extraParams);
+//        }
+
+//        String jobId = getRequiredParam(parameters, "jobId", NAME);
         JobsApi api = new JobsApi(getApiClient(parent.domino));
-        DominoJobsInterfaceJob job = api.getJob(jobId);
+        DominoJobsInterfaceJob job = api.getJob(alternateJobId);
         output(job, parent.domino);
     }
 }

--- a/src/main/java/com/ksm/domino/cli/command/run/RunList.java
+++ b/src/main/java/com/ksm/domino/cli/command/run/RunList.java
@@ -19,7 +19,7 @@ public class RunList extends AbstractDominoCommand {
 
     private static final String NAME = "run list";
 
-    @CommandLine.Parameters(description = "@|blue Optional parameters:%n userId=hsimpson%n|@%n", mapFallbackValue = "")
+    @CommandLine.Parameters(description = "@|blue Required parameters:%n userId=hsimpson%n|@%n", mapFallbackValue = "")
     private final Map<String, String> parameters = new LinkedHashMap<>(3);
 
     @Override


### PR DESCRIPTION
Fix #43 

The issue: printing out the stack trace instead of a user-friendly error message and the help menu

The fix: Modify how which error is being thrown in AbstractDominoCommand

Old Code flow: 
In “getRequiredParam”, the function “Validate.notBlank” will either throw a NullPointerException or an IllegalArgumentException upon two different non valid input types. NullPointerException is thrown when the argument hasn’t been specified at all (ie: domino job get) and the IllegalArgumentException is thrown when the input is considered “blank” (ie: domino job get jobId). If the error thrown is a NullPointerException, it goes into the broad “Exception e” catch statement and just throws a RuntimeError, showing the stack trace.

New Code flow:
In “getRequiredParam”, when the “Validate.notBlank” function throws an exception, catch it and throw an IllegalArgumentException with a message. The IllegalArgumentException gets tossed up to the built in PicoCLI parameters exception handler. That will print out the error message (in red) and also display the help menu.
